### PR TITLE
Require Sprockets

### DIFF
--- a/lib/npm_assets/npm_require_processor.rb
+++ b/lib/npm_assets/npm_require_processor.rb
@@ -1,4 +1,5 @@
 module NpmAssets
+  require 'sprockets'
   class NpmRequireProcessor < Sprockets::DirectiveProcessor
     
     def process_require_npm_directive(path)


### PR DESCRIPTION
Minor tweak to require sprockets if hasn't been required before the rake task runs.

This is my first pull request, so if I'm doing it wrong, please let me know.

Thanks,
Scot
