### PR TITLE
Scan JavaScript files as well as CoffeeScript files for the presence of require_npm.

### DIFF
--- a/lib/tasks/npm_assets.rake
+++ b/lib/tasks/npm_assets.rake
@@ -3,9 +3,11 @@ namespace :npm_assets do
   desc "go thru all the coffee files, look for require_npm and add dependencies to package.json"
   task :build_package_json => :environment do
     npms = []
-    FileList["app/assets/javascripts/**/*.coffee", "spec/javascripts/**/*.coffee"].each do |f|
+    FileList["app/assets/javascripts/**/*.coffee", "spec/javascripts/**/*.coffee",
+             "app/assets/javascripts/**/*.js", "spec/javascripts/**/*.js"].each do |f|
+      require_matcher = f.ends_with?("coffee") ? /^#=\s+require_npm\s+([\w_-]*)/ : /^\/\/=\s+require_npm\s+([\w_-]*)/
       File.new(f).each_line do |line|
-        match = line.match(/^#=\s+require_npm\s+([\w_-]*)/)
+        match = line.match(require_matcher)
         npms << match[1] if match
       end
     end


### PR DESCRIPTION
I'm using JavaScript, not CoffeeScript, in my project and still npm_assets is useful, but it was not scanning for the presence of require_npm in js files, so I implemented it. Let me know if you want it implement it in some other way or style.
