### PR TITLE
Don't crash when running assets:precompile due to file not founds, like:...

### DIFF
--- a/lib/npm_assets/rails.rb
+++ b/lib/npm_assets/rails.rb
@@ -7,9 +7,14 @@ module NpmAssets
     end
     initializer "npm_assets.add_asset_paths" do |app|
       FileList["#{app.root}/**/node_modules/*"].each do |dir|
-        package = ActiveSupport::JSON.decode(File.read(File.join(dir, "package.json")))
-        match = package["main"].match(/.*\//)
-        app.config.assets.paths << (match ? File.join(dir, match[0]) : dir)
+        file_name = File.join(dir, "package.json")
+        if File.exist?(file_name)
+          package = ActiveSupport::JSON.decode(File.read(file_name))
+          match = package["main"].match(/.*\//)
+          app.config.assets.paths << (match ? File.join(dir, match[0]) : dir)
+        else
+          puts "When searching for npm_assets, file not found: #{file_name}"
+        end
       end
     end
     rake_tasks do


### PR DESCRIPTION
... public/assets/node_modules/eve/package.json.

When running rake assets:precompile, the files are copied to public/assets after get the hash added to the filename, so package.json is not found, instead there's: package-ff1fdbca93176ffaabcec09189d4a6b4.json

I'm not sure if this is the right fix, but at least, I can run assets:precompile.
